### PR TITLE
I18n: Improve language detection and manual overrides.

### DIFF
--- a/assets/scripts/media-library-modal.js
+++ b/assets/scripts/media-library-modal.js
@@ -13,7 +13,7 @@
 
 			filters.all = {
 				// Change this: use whatever default label you'd like
-				text:  'Search Imageshop',
+				text: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.origins.imageshop : 'Search Imageshop' ),
 				props: {
 					// Change this: key needs to be the WP_Query var for the taxonomy
 					imageshop_origin: 'imageshop'
@@ -23,7 +23,7 @@
 
 			filters.wp = {
 				// Change this: use whatever default label you'd like
-				text:  'Search WordPress library',
+				text: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.origins.wordpress : 'Search WordPress library' ),
 				props: {
 					// Change this: key needs to be the WP_Query var for the taxonomy
 					imageshop_origin: 'wordpress'
@@ -57,7 +57,7 @@
 			});
 			filters.all = {
 				// Change this: use whatever default label you'd like
-				text:  'All interfaces',
+				text:  ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.interfaces.all : 'All interfaces' ),
 				props: {
 					// Change this: key needs to be the WP_Query var for the taxonomy
 					imageshop_interface: '0'
@@ -76,7 +76,7 @@
 
 			filters.all = {
 				// Change this: use whatever default label you'd like
-				text:  '10 results per page',
+				text: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.pagination.all : '25 results per page' ),
 				props: {
 					// Change this: key needs to be the WP_Query var for the taxonomy
 					posts_per_page: 25
@@ -86,6 +86,48 @@
 			this.filters = filters;
 		}
 	});
+
+	let ImageshopLanguageFilter = wp.media.view.AttachmentFilters.extend({
+		id: 'imageshop-media-library-language',
+
+		createFilters: function() {
+			var filters = {};
+			var defaultFilter = {
+				slug: '',
+				language: {
+					label: ''
+				}
+			};
+
+			if ( ImageshopMediaLibrary.languages ) {
+				for ( const[ slug, language ] of Object.entries( ImageshopMediaLibrary.languages ) ) {
+					if ( language.default ) {
+						defaultFilter = {
+							slug,
+							language,
+						};
+					}
+
+					filters[ slug ] = {
+						text: language.label,
+						props: {
+							imageshop_language: slug,
+						}
+					};
+				}
+			}
+			filters.all = {
+				// Change this: use whatever default label you'd like
+				text: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.language.all : 'Language' ),
+				props: {
+					// Change this: key needs to be the WP_Query var for the taxonomy
+					imageshop_language: ''
+				},
+				priority: 10
+			};
+			this.filters = filters;
+		}
+	})
 
 	let ImageshopCategoryFilters = wp.media.view.AttachmentFilters.extend({
 		id: 'imageshop-media-library-category',
@@ -118,7 +160,7 @@
 			}
 			filters.all = {
 				// Change this: use whatever default label you'd like
-				text:  'All categories',
+				text: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.categories.all : 'All categories' ),
 				props: {
 					// Change this: key needs to be the WP_Query var for the taxonomy
 					imageshop_category: ''
@@ -139,7 +181,7 @@
 			AttachmentsBrowser.prototype.createToolbar.call( this );
 
 			this.toolbar.set( 'ImageshopOriginFiltersLabel', new wp.media.view.Label({
-				value: 'Media library source origin',
+				value: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.origins.label : 'Media library source origin' ),
 				attributes: {
 					'for': 'imageshop-media-library-origin'
 				},
@@ -152,7 +194,7 @@
 			}).render() );
 
 			this.toolbar.set( 'ImageshopInterfaceFiltersLabel', new wp.media.view.Label({
-				value: 'Imageshop Interface',
+				value: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.interfaces.label : 'Imageshop Interface' ),
 				attributes: {
 					'for': 'imageshop-media-library-interface'
 				},
@@ -164,8 +206,21 @@
 				priority: -75
 			}).render() );
 
+			this.toolbar.set( 'ImageshopLanguageFilterLabel', new wp.media.view.Label({
+				value: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.language.label : 'Imageshop Language' ),
+				attributes: {
+					'for': 'imageshop-media-library-language'
+				},
+				priority: -75
+			}).render() );
+			this.toolbar.set( 'ImageshopLanguageFilter', new ImageshopLanguageFilter({
+				controller: this.controller,
+				model: this.collection.props,
+				priority: -75
+			}).render() );
+
 			this.toolbar.set( 'ImageshopCategoryFiltersLabel', new wp.media.view.Label({
-				value: 'Imageshop Category',
+				value: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.categories.label : 'Imageshop Category' ),
 				attributes: {
 					'for': 'imageshop-media-library-category'
 				},
@@ -178,7 +233,7 @@
 			}).render() );
 
 			this.toolbar.set( 'ImageshopPostsPerPageFilterLabel', new wp.media.view.Label({
-				value: 'Results per page',
+				value: ( ImageshopMediaLibrary.labels ? ImageshopMediaLibrary.labels.pagination.label : 'Results per page' ),
 				attributes: {
 					'for': 'imageshop-posts-per-page'
 				},

--- a/includes/class-imageshop.php
+++ b/includes/class-imageshop.php
@@ -86,6 +86,46 @@ class Imageshop {
 		Sync::get_instance();
 	}
 
+	public static function available_locales() {
+		return array(
+			'dk' => array(
+				'label'     => esc_html__( 'Danish', 'imageshop-dam-connector' ),
+				'default'   => false,
+				'iso_codes' => array(
+					'da'    => 'string',
+					'dk'    => 'string',
+					'da_DK' => 'string',
+				),
+			),
+			'en' => array(
+				'label'     => esc_html__( 'English', 'imageshop-dam-connector' ),
+				'default'   => false,
+				'iso_codes' => array(
+					'/en_*/' => 'regex',
+				),
+			),
+			'no' => array(
+				'label'     => esc_html__( 'Norwegian', 'imageshop-dam-connector' ),
+				'default'   => true,
+				'iso_codes' => array(
+					'nb'    => 'string',
+					'nn'    => 'string',
+					'nb_NO' => 'string',
+					'nn_NO' => 'string',
+				),
+			),
+			'sv' => array(
+				'label'     => esc_html__( 'Swedish', 'imageshop-dam-connector' ),
+				'default'   => false,
+				'iso_codes' => array(
+					'se'    => 'string',
+					'sv'    => 'string',
+					'sv_SE' => 'string',
+				),
+			),
+		);
+	}
+
 	/**
 	 * Enqueue scripts.
 	 */

--- a/includes/class-library.php
+++ b/includes/class-library.php
@@ -74,6 +74,30 @@ class Library {
 				'interfaces'        => $imageshop->get_interfaces(),
 				'default_interface' => (int) \get_option( 'imageshop_upload_interface' ),
 				'categories'        => $imageshop->get_categories(),
+				'languages'         => Imageshop::available_locales(),
+				'labels'            => array(
+					'origins'    => array(
+						'label'     => esc_html__( 'Media library source origin', 'imageshop-dam-connector' ),
+						'imageshop' => esc_html__( 'Search Imageshop', 'imageshop-dam-connector' ),
+						'wordpress' => esc_html__( 'Search WordPress library', 'imageshop-dam-connector' ),
+					),
+					'interfaces' => array(
+						'label' => esc_html__( 'Imageshop Interface', 'imageshop-dam-connector' ),
+						'all'   => esc_html__( 'All interfaces', 'imageshop-dam-connector' ),
+					),
+					'language'   => array(
+						'label' => esc_html__( 'Imageshop Language', 'imageshop-dam-connector' ),
+						'all'   => esc_html__( 'Language', 'imageshop-dam-connector' ),
+					),
+					'categories' => array(
+						'label' => esc_html__( 'Imageshop Category', 'imageshop-dam-connector' ),
+						'all'   => esc_html__( 'All categories', 'imageshop-dam-connector' ),
+					),
+					'pagination' => array(
+						'label' => esc_html__( 'Results per page', 'imageshop-dam-connector' ),
+						'all'   => esc_html__( '25 results per page', 'imageshop-dam-connector' ),
+					),
+				),
 			)
 		);
 		// Overrides code styling to accommodate for a third dropdown filter

--- a/includes/class-search.php
+++ b/includes/class-search.php
@@ -133,6 +133,10 @@ class Search {
 			'CategoryIds'   => null,
 		);
 
+		if ( isset( $_POST['query']['imageshop_language'] ) && ! empty( $_POST['query']['imageshop_language'] ) ) {
+			$this->imageshop->set_language( $_POST['query']['imageshop_language'] );
+		}
+
 		$search_attributes = $this->validate_and_assign_search_attributes( $search_attributes, $_POST['query'] );
 
 		$search_results = $this->imageshop->search( $search_attributes );

--- a/readme.txt
+++ b/readme.txt
@@ -33,8 +33,11 @@ We welcome both suggestions, discussions, and code! Check out the project source
 == Changelog ==
 
 = 0.0.7 (TBD) =
-* Added fallback handling if an API key is changed, to allow old images to render still
+* Added fallback handling if an API key is changed, to allow old images to render still.
+* Added alternative to manually change the Imageshop lookup language when filtering media results.
+* Added translation wrappers for labels used within the media modal.
 * Improved the API settings screen to flush data when an existing API key is modified.
+* Improved handling of site languages to determine default Imageshop lookup languages.
 
 = 0.0.6 (2022-12-05) =
 * Initial release


### PR DESCRIPTION
This improves the detection of the default language of a site to use as the default lookup language when making calls to the Imageshop API, ensuring that the site language is used as the basis for fields such as: description, alt texts, and captions.

A new filter selection for languages has also been introduced, allowing the editor to switch which language is being returned from Imageshop calls, regardless of their sites language options.

And finally, media modal languages have had their strings passed through translation functions, allowing for future translations to improve the overall experience.