### PR TITLE
Feature: WebP media support

### DIFF
--- a/includes/REST/Settings.php
+++ b/includes/REST/Settings.php
@@ -40,6 +40,7 @@ class Settings {
 		$api_key           = \get_option( 'imageshop_api_key', '' );
 		$default_interface = \get_option( 'imageshop_upload_interface', '' );
 		$disable_srcset    = \get_option( 'imageshop_disable_srcset', 'no' );
+		$webp_support      = \get_option( 'imageshop_webp_support', 'no' );
 
 		$valid_api = ! empty( $api_key ) && $imageshop->test_valid_token();
 
@@ -53,6 +54,7 @@ class Settings {
 			'original_api_key'  => $api_key,
 			'default_interface' => $default_interface,
 			'disable_srcset'    => $disable_srcset,
+			'webp_support'      => $webp_support,
 			'has_valid_api_key' => $valid_api,
 			'interfaces'        => $interfaces,
 		];
@@ -66,6 +68,7 @@ class Settings {
 		$api_key           = $request->get_param( 'api_key' );
 		$default_interface = $request->get_param( 'default_interface' );
 		$disable_srcset    = $request->get_param( 'disable_srcset' );
+		$webp_support      = $request->get_param( 'webp_support' );
 
 		if ( ! empty( $api_key ) ) {
 			\update_option( 'imageshop_api_key', $api_key );
@@ -77,6 +80,10 @@ class Settings {
 
 		if ( ! is_null( $disable_srcset ) ) {
 			\update_option( 'imageshop_disable_srcset', $disable_srcset );
+		}
+
+		if ( ! is_null( $webp_support ) ) {
+			\update_option( 'imageshop_webp_support', $webp_support );
 		}
 
 		return new WP_REST_Response( [

--- a/includes/class-attachment.php
+++ b/includes/class-attachment.php
@@ -1312,7 +1312,12 @@ class Attachment {
 		$filename = \sanitize_title( $filename );
 
 		// Append a file extension for the file, this is always `.jpg` (unless webp support is enabled).
-		$filename .= '.jpg';
+		$use_webp = \get_option( 'imageshop_webp_support', 'no' );
+		if ( 'yes' === $use_webp ) {
+			$filename .= '.webp';
+		} else {
+			$filename .= '.jpg';
+		}
 
 		return $filename;
 	}

--- a/src/Settings/Advanced/index.jsx
+++ b/src/Settings/Advanced/index.jsx
@@ -6,17 +6,37 @@ export default function Advanced( { settings, updateSettings } ) {
 		updateSettings( { disable_srcset: newState ? 'yes' : 'no' } );
 	}
 
+	const updateWebpSupportSetting = ( newState ) => {
+		updateSettings( { webp_support: newState ? 'yes' : 'no' } )
+	}
+
 	return (
 		<div className="imageshop-advanced">
 
 			<div className="grid grid-cols-1 gap-2 w-full md:max-w-lg">
 				<div className="grid grid-cols-1 gap-2">
-					<label>{ __( 'Imageshop Key:', 'imageshop-dam-connector' ) }</label>
 					<label>
 						<input
 							type="checkbox"
-							placeholder={ __( 'Enter your Imageshop key', 'imageshop-dam-connector' ) }
-							className="w-full"
+							checked={ settings.webp_support === 'yes' }
+							onChange={ ( event ) => updateWebpSupportSetting( event.target.checked ) }
+						/>
+						<span>
+							{ __( 'Enable WebP image support', 'imageshop-dam-connector' ) }
+						</span>
+					</label>
+
+					<p>
+						{ __( 'WebP is a modern image format optimized for websites, not all themes support WebP images, but when possible you may gain some performance improvement by enabling this feature.', 'imageshop-dam-connector' ) }
+					</p>
+				</div>
+
+				<hr />
+
+				<div className="grid grid-cols-1 gap-2">
+					<label>
+						<input
+							type="checkbox"
 							checked={ settings.disable_srcset === 'yes' }
 							onChange={ ( event ) => updateSrcsetSetting( event.target.checked ) }
 						/>

--- a/src/Settings/index.jsx
+++ b/src/Settings/index.jsx
@@ -44,6 +44,7 @@ export default function Settings() {
 					api_key: settings.api_key,
 					default_interface: settings.default_interface,
 					disable_srcset: settings.disable_srcset,
+					webp_support: settings.webp_support,
 				}
 			}
 		).then( ( response ) => {


### PR DESCRIPTION
This introduces a means of changing the media format for images to return WebP variants of images instead of JPEG.

By default, WebP images are disabled, as some sites may not directly support it without modifying the styles of their site, but it can be enabled or disabled via the advanced settings tab.