### PR TITLE
Bugfix/Fix Edge Case Causing HTTP Requests Loops

### DIFF
--- a/includes/API/REST_Controller.php
+++ b/includes/API/REST_Controller.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class REST_Controller {
 	private const IMAGESHOP_API_BASE_URL               = 'https://api.imageshop.no';
-	public const IMAGESHOP_CDN_PREFIX                 = 'https://v.imgi.no';
+	public const IMAGESHOP_CDN_PREFIX                  = 'https://v.imgi.no';
 	private const IMAGESHOP_API_CAN_UPLOAD             = '/Login/CanUpload';
 	private const IMAGESHOP_API_WHOAMI                 = '/Login/WhoAmI';
 	private const IMAGESHOP_API_CREATE_DOCUMENT        = '/Document/CreateDocument';

--- a/includes/API/REST_Controller.php
+++ b/includes/API/REST_Controller.php
@@ -683,6 +683,13 @@ class REST_Controller {
 	 * @return array|mixed|object
 	 */
 	public function get_document( $id ) {
+		$cache_key = $this->get_document_cache_key( $id, $this->language );
+
+		$cached = \get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
 		$url  = \add_query_arg(
 			array(
 				'language'   => $this->language,
@@ -701,7 +708,51 @@ class REST_Controller {
 			return (object) array();
 		}
 
+		// Only cache complete documents: the API can return a 200 with an empty/error body
+		// for a deleted or inaccessible document, and pinning that for the full TTL is worse
+		// than re-requesting it. Throttling those is left to the caller's negative cache.
+		if ( \is_object( $ret ) && isset( $ret->SubDocumentList ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- `$ret->SubDocumentList` is provided by the SaaS API.
+			\set_transient( $cache_key, $ret, (int) \apply_filters( 'imageshop_document_cache_ttl', \DAY_IN_SECONDS, $id ) );
+		}
+
 		return $ret;
+	}
+
+	/**
+	 * Build the transient key used to cache a single document lookup.
+	 *
+	 * Keyed by language because the API returns locale-specific metadata, and by the active
+	 * token so the cache is scoped to one account and is transparently invalidated when the
+	 * credentials change.
+	 *
+	 * @param int    $id       The Imageshop document ID.
+	 * @param string $language The language code the document was requested in.
+	 *
+	 * @return string
+	 */
+	private function get_document_cache_key( $id, string $language ): string {
+		$account = \substr( \md5( (string) $this->api_token ), 0, 8 );
+
+		return 'imageshop_document_' . $account . '_' . $language . '_' . $id;
+	}
+
+	/**
+	 * Remove any cached lookups for a single document across all known languages.
+	 *
+	 * @param int $id The Imageshop document ID.
+	 *
+	 * @return void
+	 */
+	public function delete_document_cache( $id ): void {
+		$languages = \array_keys( Imageshop::available_locales() );
+
+		// Always cover the default 'en' fallback as well as the currently active language.
+		$languages[] = 'en';
+		$languages[] = $this->language;
+
+		foreach ( \array_unique( $languages ) as $language ) {
+			\delete_transient( $this->get_document_cache_key( $id, $language ) );
+		}
 	}
 
 	/**

--- a/includes/Media/Attachment.php
+++ b/includes/Media/Attachment.php
@@ -101,6 +101,13 @@ class Attachment {
 		// Delete the stored metadata.
 		\delete_post_meta( $request->get_param( 'id' ), '_imageshop_media_sizes' );
 
+		// A manual flush is an explicit request for fresh data, so bypass both caches.
+		$document_id = \get_post_meta( $request->get_param( 'id' ), '_imageshop_document_id', true );
+		if ( ! empty( $document_id ) ) {
+			REST_Controller::get_instance()->delete_document_cache( $document_id );
+		}
+		$this->clear_attachment_unresolved( $request->get_param( 'id' ) );
+
 		// generate new metadata, which will also generate new permalinks as needed.
 		$this->generate_imageshop_metadata( get_post( $request->get_param( 'id' ) ) );
 
@@ -546,6 +553,11 @@ class Attachment {
 			return array();
 		}
 
+		// An unresolved document would otherwise trigger one API request per registered size.
+		if ( $this->is_attachment_unresolved( $attachment_id ) ) {
+			return array();
+		}
+
 		$max_srcset_image_width = apply_filters( 'max_srcset_image_width', 2048, $size_array );
 
 		foreach ( \wp_get_registered_image_subsizes() as $slug => $data ) {
@@ -774,11 +786,8 @@ class Attachment {
 			return $image;
 		}
 
-		/*
-		 * If the media has been attempted fetched previously, and we're still
-		 * waiting for Imageshop to process it, return the original image.
-		 */
-		if ( false !== \get_transient( '_imageshop_attachment_' . $attachment_id . '_processing' ) ) {
+		// Imageshop is still processing the source, or it could not be resolved; serve the original meanwhile.
+		if ( $this->is_attachment_unresolved( $attachment_id ) ) {
 			return $image;
 		}
 
@@ -933,8 +942,7 @@ class Attachment {
 				// Remove the still faulty metadata, as keeping it may lead to unintentional processing.
 				\delete_post_meta( $attachment_id, '_imageshop_media_sizes' );
 
-				// Set a value to prevent processing for 5 minutes to avoid unnecessary server strain while data is generated.
-				\set_transient( '_imageshop_attachment_' . $attachment_id . '_processing', 'processing', 5 * MINUTE_IN_SECONDS );
+				$this->mark_attachment_unresolved( $attachment_id );
 
 				return $image;
 			}
@@ -1059,6 +1067,9 @@ class Attachment {
 
 		// If no valid media object is returned for any reason, bail early.
 		if ( empty( $media ) || ! isset( $media->SubDocumentList ) ) { // / phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- `$media->SubDocumentList` are provided by the SaaS API.
+			// Nothing is persisted on this path, so throttle to avoid an API call on every render.
+			$this->mark_attachment_unresolved( $post->ID );
+
 			return $media_details;
 		}
 
@@ -1144,6 +1155,34 @@ class Attachment {
 
 	public function append_document( $document_id, $document_details ) {
 		$this->documents[ $document_id ] = $document_details;
+	}
+
+	/**
+	 * Flag an attachment whose Imageshop document could not be resolved.
+	 */
+	private function mark_attachment_unresolved( $attachment_id ): void {
+		\set_transient( $this->get_processing_transient_key( $attachment_id ), 'processing', 5 * \MINUTE_IN_SECONDS );
+	}
+
+	/**
+	 * Check if an attachment is currently flagged as unresolved.
+	 */
+	private function is_attachment_unresolved( $attachment_id ): bool {
+		return false !== \get_transient( $this->get_processing_transient_key( $attachment_id ) );
+	}
+
+	/**
+	 * Clear the unresolved flag for an attachment.
+	 */
+	private function clear_attachment_unresolved( $attachment_id ): void {
+		\delete_transient( $this->get_processing_transient_key( $attachment_id ) );
+	}
+
+	/**
+	 * Generate a unique transient key for tracking the processing state of an attachment.
+	 */
+	private function get_processing_transient_key( $attachment_id ): string {
+		return '_imageshop_attachment_' . $attachment_id . '_processing';
 	}
 
 	public static function get_document_original_file( $media, $fallback = array() ) {
@@ -1347,6 +1386,9 @@ class Attachment {
 
 		$media = $this->get_document( $document_id );
 		if ( empty( $media ) || ! isset( $media->SubDocumentList ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- `$media->SubDocumentList` is provided by the SaaS API.
+			// Throttle here too: the srcset filters resolve sizes without going through generate_imageshop_metadata().
+			$this->mark_attachment_unresolved( $attachment_id );
+
 			return null;
 		}
 


### PR DESCRIPTION
There appears to be an edge case where every front-end render can fire a synchronous `GetDocumentById` call per image - 8 images means ~8 × 280ms of blocking HTTP on render.

The root cause: `GetDocumentById` is the only expensive API call with no persistent cache. The only thing keeping it off the front end was the `_imageshop_media_sizes` post meta, and that meta only gets written when the API returns a usable document. When a document comes back as an HTTP 200 with an empty/error body (deleted, archived, or inaccessible), nothing was persisted and nothing throttled it - so we re-requested it on every single load.

## What this does

- **Caches `get_document()`** in a transient (keyed by language + account, valid responses only). Broken 200s are deliberately left uncached so we don't pin junk for a day.
- **Negative-caches unresolved documents** using the existing "processing" throttle, in both the metadata and srcset paths, so a broken document costs at most one call per 5 minutes instead of one per render.
- **Busts both caches** on a manual "re-create references" flush so editors get fresh data.
